### PR TITLE
Slight bug in pardon command handling.

### DIFF
--- a/name/richardson/james/banhammer/ban/BanHandler.java
+++ b/name/richardson/james/banhammer/ban/BanHandler.java
@@ -149,7 +149,7 @@ public class BanHandler {
     if (this.isPlayerBanned(playerName)) {
         this.cache.remove(playerName);
         BanRecord.findFirst(playerName).destroy();
-        Logger.info(String.format(BanHammer.getMessage("player-pardoned"), senderName, playerName));
+        Logger.info(String.format(BanHammer.getMessage("player-pardoned-by"), senderName, playerName));
         if (notify) {
           server.broadcast(String.format(ChatColor.GREEN + BanHammer.getMessage("broadcast-player-pardoned"), playerName), "banhammer.notify");
         }

--- a/name/richardson/james/banhammer/ban/PardonCommand.java
+++ b/name/richardson/james/banhammer/ban/PardonCommand.java
@@ -47,6 +47,8 @@ public class PardonCommand extends Command {
     
     if (!this.banHandler.pardonPlayer(arguments.get("playerName"), senderName, true)) {
       sender.sendMessage(String.format(ChatColor.YELLOW + BanHammer.getMessage("player-not-banned"), arguments.get("playerName")));
+    } else {
+      sender.sendMessage(String.format(ChatColor.GREEN + BanHammer.getMessage("player-pardoned"), arguments.get("playerName")));
     }
     
   }

--- a/name/richardson/james/banhammer/localisation/Messages.properties
+++ b/name/richardson/james/banhammer/localisation/Messages.properties
@@ -29,7 +29,7 @@ log-player-banned: %s has banned %s.
 player-kicked: %s has kicked %s.
 player-banned-temporarily: %s has banned %s for %s.
 player-bans-purged: %s has deleted all bans associated with %s.
-player-pardoned: %s has pardoned %s.
+player-pardoned-by: %s has pardoned %s.
 cache-reloaded: %s has reloaded the ban cache.
 ban-export: %s has exported all bans to banned-players.txt.
 ban-import: %s has imported %d bans from banned-players.txt.


### PR DESCRIPTION
Fixed a duplicated entry for player-pardoned in the localization file which meant the console printed a message saying the source had been pardoned, instead of the target. I've renamed the option to player-pardoned-by to distinguish between a message to the source, and a message to the console.

Also added a reply (player-pardoned) to the source if the player has been successfully pardoned, before if the player was successfully pardoned the source was not told, which lead to some confusion.

Hope this Helps,

-Keith
