### PR TITLE
ClassCastException when dealing with alternate CommandSender implementations

### DIFF
--- a/src/main/java/name/richardson/james/bukkit/banhammer/ban/CheckCommand.java
+++ b/src/main/java/name/richardson/james/bukkit/banhammer/ban/CheckCommand.java
@@ -71,7 +71,7 @@ public class CheckCommand extends AbstractCommand {
 
   public void parseArguments(final String[] arguments, final CommandSender sender) throws CommandArgumentException {
     if (arguments.length == 0) {
-      if (sender instanceof ConsoleCommandSender) {
+      if (!(sender instanceof Player)) {
         throw new CommandArgumentException(this.getLocalisation().getMessage(BanHammer.class, "must-specify-player"), null);
       }
       this.player = (OfflinePlayer) sender;

--- a/src/main/java/name/richardson/james/bukkit/banhammer/ban/HistoryCommand.java
+++ b/src/main/java/name/richardson/james/bukkit/banhammer/ban/HistoryCommand.java
@@ -85,7 +85,7 @@ public class HistoryCommand extends AbstractCommand {
 
   public void parseArguments(final String[] arguments, final CommandSender sender) throws CommandArgumentException {
     if (arguments.length == 0) {
-      if (sender instanceof ConsoleCommandSender) {
+      if (!(sender instanceof Player)) {
         throw new CommandArgumentException(this.getLocalisation().getMessage(BanHammer.class, "must-specify-player"), null);
       }
       this.playerName = sender.getName();


### PR DESCRIPTION
When interacting with BanHammer via rcon and Minecraft's command blocks, using certain commands incorrectly (i.e. 'bh check' or 'bh history' with no parameters) causes ClassCastExceptions. When used with command blocks, this crashes the server.

Instead of checking specifically for ConsoleCommandSender, we should check if the sender was a player or not, as these commands without parameters only make sense for Players (offline or otherwise).
