### PR TITLE
Fix problem with casesensitive .get() method in java maps.

### DIFF
--- a/src/main/java/name/richardson/james/bukkit/banhammer/ban/BanCommand.java
+++ b/src/main/java/name/richardson/james/bukkit/banhammer/ban/BanCommand.java
@@ -139,7 +139,7 @@ public class BanCommand extends AbstractAsynchronousCommand {
 	}
 
 	private boolean isBanWithinLimit() {
-		if (time.getTime() == 0 && isAuthorised(PERMISSION_PERMANENT)) {       
+		if (isAuthorised(PERMISSION_PERMANENT)) {       
                     return true;
 		}
                 if(time.getTime() != 0) {

--- a/src/main/java/name/richardson/james/bukkit/banhammer/ban/BanCommand.java
+++ b/src/main/java/name/richardson/james/bukkit/banhammer/ban/BanCommand.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 
 import org.bukkit.Server;
 import org.bukkit.plugin.Plugin;
@@ -138,9 +139,10 @@ public class BanCommand extends AbstractAsynchronousCommand {
 	}
 
 	private boolean isBanWithinLimit() {
-		if (time.getTime() == 0 && isAuthorised(PERMISSION_PERMANENT)) {
-			return true;
-		} else {
+		if (time.getTime() == 0 && isAuthorised(PERMISSION_PERMANENT)) {       
+                    return true;
+		}
+                if(time.getTime() != 0) {
 			for (final Map.Entry<String, Long> limit : configuration.getBanLimits().entrySet()) {
 				String node = getPermissionFromLimit(limit.getKey());
 				if (!isAuthorised(node)) continue;

--- a/src/main/java/name/richardson/james/bukkit/banhammer/ban/BanCommand.java
+++ b/src/main/java/name/richardson/james/bukkit/banhammer/ban/BanCommand.java
@@ -42,6 +42,7 @@ import name.richardson.james.bukkit.banhammer.argument.SilentSwitchArgument;
 import name.richardson.james.bukkit.banhammer.argument.TimeMarshaller;
 import name.richardson.james.bukkit.banhammer.argument.TimeOptionArgument;
 import name.richardson.james.bukkit.banhammer.model.PlayerNotFoundException;
+import org.bukkit.Bukkit;
 
 public class BanCommand extends AbstractAsynchronousCommand {
 
@@ -53,9 +54,13 @@ public class BanCommand extends AbstractAsynchronousCommand {
 	private final Argument reason;
 	private final SilentSwitchArgument silent;
 	private final TimeMarshaller time;
-
+        private final Plugin plugin;
+        private final BukkitScheduler scheduler;
+        
 	public BanCommand(final Plugin plugin, final BukkitScheduler scheduler, BanHammerPluginConfiguration configuration, Server server) {
 		super(plugin, scheduler);
+                this.plugin = plugin;
+                this.scheduler = scheduler;
 		this.configuration = configuration;
 		player = PlayerNamePositionalArgument.getInstance(server, 0, true);
 		time = (TimeMarshaller) TimeOptionArgument.getInstance();
@@ -70,8 +75,8 @@ public class BanCommand extends AbstractAsynchronousCommand {
 	@Override
 	public void execute() {
 		Collection<String> playerNames = player.getStrings();
-		Collection<BanRecord> records = new ArrayList<BanRecord>();
-		boolean silent = this.silent.isSet();
+		final Collection<BanRecord> records = new ArrayList<BanRecord>();
+		final boolean silent = this.silent.isSet();
 		long time = this.time.getTime();
 		PlayerRecord creatorRecord;
 		try {
@@ -94,8 +99,13 @@ public class BanCommand extends AbstractAsynchronousCommand {
 					addMessage(MESSAGES.unableToBanForThatLong(playerName));
 				}
 			}
-			new BanHammerPlayerBannedEvent(records, getContext().getCommandSender(), silent);
-		} catch (PlayerNotFoundException e) {
+                       this.scheduler.scheduleSyncDelayedTask(this.plugin, new Runnable() {
+                        @Override
+                        public void run() {
+                            new BanHammerPlayerBannedEvent(records, getContext().getCommandSender(), silent);
+                                }
+                        }, 0L);
+                        } catch (PlayerNotFoundException e) {
 			addMessage(MESSAGES.playerLookupException());
 		}
 	}

--- a/src/main/java/name/richardson/james/bukkit/banhammer/ban/event/PlayerListener.java
+++ b/src/main/java/name/richardson/james/bukkit/banhammer/ban/event/PlayerListener.java
@@ -72,7 +72,7 @@ public final class PlayerListener extends AbstractListener {
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	public void onPlayerLogin(final PlayerLoginEvent event) {
 		Player player = event.getPlayer();
-		if (!server.getOnlineMode()) return;
+		//if (!server.getOnlineMode()) return;
 		if (event.getResult() == PlayerLoginEvent.Result.KICK_BANNED) return;
 		PlayerRecord playerRecord = PlayerRecord.find(player.getUniqueId());
 		if (playerRecord != null) {

--- a/src/main/java/name/richardson/james/bukkit/banhammer/model/UUIDFetcher.java
+++ b/src/main/java/name/richardson/james/bukkit/banhammer/model/UUIDFetcher.java
@@ -37,7 +37,7 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 
 public class UUIDFetcher implements Callable<Map<String, UUID>> {
-
+    
 	private static final Map<String, UUID> CACHE = Collections.synchronizedMap(new WeakHashMap<String, UUID>());
 	private static final double PROFILES_PER_REQUEST = 100;
 	private static final String PROFILE_URL = "https://api.mojang.com/profiles/minecraft";
@@ -81,7 +81,7 @@ public class UUIDFetcher implements Callable<Map<String, UUID>> {
 	}
 
 	public static UUID getUUIDOf(String name) {
-		if (!CACHE.containsKey(name)) {
+		if (!CACHE.containsKey(name.toLowerCase())) {
 			UUIDFetcher fetcher = new UUIDFetcher(Arrays.asList(name));
 			try {
 				CACHE.putAll(fetcher.call());
@@ -89,7 +89,7 @@ public class UUIDFetcher implements Callable<Map<String, UUID>> {
 				e.printStackTrace();
 			}
 		}
-		return CACHE.get(name);
+		return CACHE.get(name.toLowerCase());
 	}
 
 	public static byte[] toBytes(UUID uuid) {
@@ -119,7 +119,7 @@ public class UUIDFetcher implements Callable<Map<String, UUID>> {
 			for (Object profile : array) {
 				JSONObject jsonProfile = (JSONObject) profile;
 				String id = (String) jsonProfile.get("id");
-				String name = (String) jsonProfile.get("name");
+				String name = (String) jsonProfile.get("name").toString().toLowerCase();
 				UUID uuid = UUIDFetcher.getUUID(id);
 				uuidMap.put(name, uuid);
 			}


### PR DESCRIPTION
Due to the fact that player names (mojang api) are not case sensitive but the API returns the case corrected player name CACHE.containsKey() and CACHE.get() will not return the correct uuid if you ban the player with wrong name (not case correct).

____ I hate it if i commit with the wrong name  ;)____
